### PR TITLE
Rename vars and stuff: cloudwatch events is the proper name of the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | allow\_read\_iam\_arns | Allow these IAM users/roles to read messages in the queue.  Not used when `policy` is specified. | `list(string)` | `[]` | no |
-| allow\_write\_eventbridge\_rules | Allow these EventBridge rule ARNs to create messages in the queue.  Not used when `policy` is specified. | `list(string)` | `[]` | no |
+| allow\_write\_cloudwatch\_events\_rules | Allow these CloudWatch Events rule ARNs to create messages in the queue.  Not used when `policy` is specified. | `list(string)` | `[]` | no |
 | allow\_write\_iam\_arns | Allow these IAM users/roles to create and manage messages in the queue.  Not used when `policy` is specified. | `list(string)` | `[]` | no |
 | content\_based\_deduplication | Enables content-based deduplication for FIFO queues | `bool` | `false` | no |
 | create | Whether to create SQS queue | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -95,9 +95,9 @@ data "aws_iam_policy_document" "this" {
     }
   }
 
-  # allow SNS and EventBridge to SendMessage to the quee
+  # allow SNS and CloudWatch Events to SendMessage to the quee
   dynamic "statement" {
-    for_each = length(var.sns_topic_subscription_arn) > 0 || length(var.allow_write_eventbridge_rules) > 0 ? [true] : []
+    for_each = length(var.sns_topic_subscription_arn) > 0 || length(var.allow_write_cloudwatch_events_rules) > 0 ? [true] : []
     content {
       sid     = "services-write"
       actions = ["sqs:SendMessage"]
@@ -112,7 +112,7 @@ data "aws_iam_policy_document" "this" {
         values = compact(
           concat(
             [var.sns_topic_subscription_arn],
-            var.allow_write_eventbridge_rules
+            var.allow_write_cloudwatch_events_rules
           )
         )
       }

--- a/variables.tf
+++ b/variables.tf
@@ -28,8 +28,8 @@ variable "allow_write_iam_arns" {
   default     = []
 }
 
-variable "allow_write_eventbridge_rules" {
-  description = "Allow these EventBridge rule ARNs to create messages in the queue.  Not used when `policy` is specified."
+variable "allow_write_cloudwatch_events_rules" {
+  description = "Allow these CloudWatch Events rule ARNs to create messages in the queue.  Not used when `policy` is specified."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
It turns out that EventBridge is just the name of the console. It, in fact, interacts with CloudWatch Events API behind the scenes.